### PR TITLE
TK-365: problème de date-heure chrome

### DIFF
--- a/tumorotek-install/src/site/markdown/index.md
+++ b/tumorotek-install/src/site/markdown/index.md
@@ -1,6 +1,6 @@
 #### Notes de version
 
-##### Version 2.2.8 - Publiée le 21/03/2023
+##### Version 2.2.8 - Publiée le 30/03/2023
 ###### Corrections
 - YouTrack [TK-368](https://tumorotek.myjetbrains.com/youtrack/issue/TK-368) : Recherche : mauvaise actualisation du nombre de résultats de la recherche, dans le titre au dessus de la liste
 - YouTrack [TK-373](https://tumorotek.myjetbrains.com/youtrack/issue/TK-373) : Export Echantillon : heures des dates toujours à 00:00 au niveau des évènements de stockage

--- a/tumorotek-install/src/site/markdown/note-version.md
+++ b/tumorotek-install/src/site/markdown/note-version.md
@@ -1,6 +1,6 @@
 #### Notes de version
 
-##### Version 2.2.8 - Publiée le 21/03/2023
+##### Version 2.2.8 - Publiée le 30/03/2023
 ###### Corrections
 - YouTrack [TK-368](https://tumorotek.myjetbrains.com/youtrack/issue/TK-368) : Recherche : mauvaise actualisation du nombre de résultats de la recherche, dans le titre au dessus de la liste
 - YouTrack [TK-373](https://tumorotek.myjetbrains.com/youtrack/issue/TK-373) : Export Echantillon : heures des dates toujours à 00:00 au niveau des évènements de stockage

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/component/CalendarBox.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/component/CalendarBox.java
@@ -65,28 +65,37 @@ public class CalendarBox extends HtmlMacroComponent
    private Calendar cal = null;
 
    private Date date = null;
+
    private Date dateShort = null;
+
    private String dateConstraint = null;
 
    // flag indiquant si le Calendarbox a été modifié
    private boolean hasChanged = false;
 
+   Timebox timeBox;
+
+   Datebox dateBox;
+
    @Override
    public void afterCompose(){
       super.afterCompose();
-      
-      ((Datebox) getFirstChild().getFirstChild()).setFormat(Labels.getLabel("validation.date.format.simple"));
-      
-      ((Timebox) getFirstChild().getLastChild()).setButtonVisible(false);
-      ((Datebox) getFirstChild().getFirstChild()).addForward("onBlur", this, "onBlur");
-      ((Timebox) getFirstChild().getLastChild()).addForward("onBlur", this, "onBlurTimebox");
-      
+
+      timeBox = (Timebox) getFirstChild().getLastChild();
+      dateBox = (Datebox) getFirstChild().getFirstChild();
+
+      dateBox.setFormat(Labels.getLabel("validation.date.format.simple"));
+      timeBox.setButtonVisible(false);
+      dateBox.addEventListener(Events.ON_BLUR, event -> {
+         timeBox.select();
+      });
+
    }
 
    /**
     * Assigne les valeurs aux boxes en dissociant les différentes 
     * composantes du Calendar.
-    * @param maladie
+    * @param c calendar
     */
    public void setValue(final Calendar c){
 
@@ -101,15 +110,6 @@ public class CalendarBox extends HtmlMacroComponent
             date = cal.getTime();
             dateShort = new Date(cal.getTimeInMillis() - hours - minutes);
          }else{
-            /*cal = Calendar.getInstance();
-            cal.set(Calendar.YEAR, 1);
-            cal.set(Calendar.MONTH, 1);
-            cal.set(Calendar.DAY_OF_MONTH, 1);
-            cal.set(Calendar.HOUR_OF_DAY, 0);
-            cal.set(Calendar.MINUTE, 0);
-            cal.set(Calendar.SECOND, 0);
-            cal.set(Calendar.MILLISECOND, 0);
-            date = cal.getTime();*/
             date = null;
             dateShort = null;
          }
@@ -155,21 +155,7 @@ public class CalendarBox extends HtmlMacroComponent
       return cal;
    }
 
-   public void onBlurTimebox(){
-      final Calendar timeCal = Calendar.getInstance();
-      if(((Timebox) getFirstChild().getLastChild()).getValue() != null){
-         timeCal.setTime(((Timebox) getFirstChild().getLastChild()).getValue());
-      }else{
-         timeCal.set(Calendar.HOUR_OF_DAY, 0);
-         timeCal.set(Calendar.MINUTE, 0);
-      }
 
-      if(timeCal.get(Calendar.HOUR_OF_DAY) == 0 && timeCal.get(Calendar.MINUTE) == 0){
-         ((Timebox) getFirstChild().getLastChild()).setValue(null);
-      }
-
-      Events.postEvent("onBlur", this, null);
-   }
 
    public boolean isHasChanged(){
       return hasChanged;
@@ -183,25 +169,7 @@ public class CalendarBox extends HtmlMacroComponent
       Clients.clearWrongValue(this);
    }
 
-   /**
-    * Lors du focus sur la date, si aucune heure n'est spécifiée dans le
-    * TimeBox, on le remplit à 00:00. Ceci est utilisé pour IE8, afin que
-    * le curseur se positionne au début de la TimeBox lors de l'utilisation
-    * des tabulations.
-    */
-   public void onFocus$dateBox(){
-      if(((Timebox) getFirstChild().getLastChild()).getValue() == null){
-         final Calendar calTmp = Calendar.getInstance();
-         calTmp.set(Calendar.YEAR, 1);
-         calTmp.set(Calendar.MONTH, 1);
-         calTmp.set(Calendar.DAY_OF_MONTH, 1);
-         calTmp.set(Calendar.HOUR_OF_DAY, 0);
-         calTmp.set(Calendar.MINUTE, 0);
-         calTmp.set(Calendar.SECOND, 0);
-         calTmp.set(Calendar.MILLISECOND, 0);
-         ((Timebox) getFirstChild().getLastChild()).setValue(calTmp.getTime());
-      }
-   }
+
 
    public void setConstraint(final String cst){
       this.dateConstraint = cst;

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/component/CalendarBox.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/component/CalendarBox.java
@@ -42,7 +42,6 @@ import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.HtmlMacroComponent;
 import org.zkoss.zk.ui.WrongValueException;
 import org.zkoss.zk.ui.event.Events;
-import org.zkoss.zk.ui.select.annotation.*;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Datebox;
 import org.zkoss.zul.Timebox;
@@ -73,8 +72,6 @@ public class CalendarBox extends HtmlMacroComponent
 
    // flag indiquant si le Calendarbox a été modifié
    private boolean hasChanged = false;
-
-
 
    @Override
    public void afterCompose(){
@@ -154,8 +151,6 @@ public class CalendarBox extends HtmlMacroComponent
       return cal;
    }
 
-
-
    public boolean isHasChanged(){
       return hasChanged;
    }
@@ -167,8 +162,6 @@ public class CalendarBox extends HtmlMacroComponent
    public void clearErrorMessage(final Calendar value){
       Clients.clearWrongValue(this);
    }
-
-
 
    public void setConstraint(final String cst){
       this.dateConstraint = cst;

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/component/CalendarBox.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/component/CalendarBox.java
@@ -42,6 +42,7 @@ import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.HtmlMacroComponent;
 import org.zkoss.zk.ui.WrongValueException;
 import org.zkoss.zk.ui.event.Events;
+import org.zkoss.zk.ui.select.annotation.*;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Datebox;
 import org.zkoss.zul.Timebox;
@@ -73,16 +74,14 @@ public class CalendarBox extends HtmlMacroComponent
    // flag indiquant si le Calendarbox a été modifié
    private boolean hasChanged = false;
 
-   Timebox timeBox;
 
-   Datebox dateBox;
 
    @Override
    public void afterCompose(){
       super.afterCompose();
 
-      timeBox = (Timebox) getFirstChild().getLastChild();
-      dateBox = (Datebox) getFirstChild().getFirstChild();
+      Timebox timeBox = (Timebox) getFirstChild().getLastChild();
+      Datebox dateBox = (Datebox) getFirstChild().getFirstChild();
 
       dateBox.setFormat(Labels.getLabel("validation.date.format.simple"));
       timeBox.setButtonVisible(false);


### PR DESCRIPTION
 + Correction de bug: remplacement du mécanisme d'addForward par eventListener
+ Amélioration de la lisibilité du code + Nettoyage :
 + suppression des commentaires tracés sur GitHub (historique) 
+ suppression de la méthode qu'on a vu ensemble : pour la prise en charge d'IE8

On peut voir que j'ai crée 2propriétés de classe (timeBox, dateBox) que on peut utiliser par tout pour remplacé le code Redondant
`((Datebox) getFirstChild().getFirstChild())`
 dans  la methode setValue.  mais ça n'apertient pas à ce ticket. 
à mon humble avis je propose:
 soit les effacer, soit creer un ticket d'refactoring du code (la methode setValue)  
