### PR TITLE
ouvrir par défaut

### DIFF
--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/echantillon/FicheEchantillonStatic.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/echantillon/FicheEchantillonStatic.java
@@ -346,9 +346,7 @@ public class FicheEchantillonStatic extends AbstractFicheStaticController
 
       drawRisquesFormatted();
 
-      setGroupInfosCompEchanOpen(
-         echantillon.getBanque() != null && (echantillon.getBanque().getContexte().getNom().equals("anatomopathologie")
-            || SessionUtils.getCurrentGatsbiContexteForEntiteId(3) != null));
+      setGroupInfosCompEchanOpen(true);
 
       // annotations
       super.setObject(echantillon);


### PR DESCRIPTION
Fiche Echantillon en lecture : pour les contextes anapat', ouvrir par défaut le paragraphe "informations complémentaires" 