### PR TITLE
TG-187 : plantage liste patients en toutes coll. d'une étude

### DIFF
--- a/tumorotek-model/src/main/java/fr/aphp/tumorotek/model/coeur/patient/Patient.java
+++ b/tumorotek-model/src/main/java/fr/aphp/tumorotek/model/coeur/patient/Patient.java
@@ -134,7 +134,7 @@ import fr.aphp.tumorotek.model.contexte.Banque;
    @NamedQuery(name = "Patient.findByIdentifiant", query = "SELECT distinct p FROM Patient p JOIN p.patientIdentifiants i "
          + "WHERE i.identifiant like ?1 AND i.pk.banque in (?2)"),
    @NamedQuery(name = "Patient.findIdentifiantsByPatientAndBanques", 
-      query = "SELECT distinct i "
+      query = "SELECT i "
          + "FROM PatientIdentifiant i "
          + "WHERE i.pk.patient = (?1) AND i.pk.banque in (?2) ORDER BY i.pk.banque.nom")
 })


### PR DESCRIPTION
c'est le distinct combiné à l'order by qui posait problème. requête sur les clés d'un objet avec jointure pour une relation 1 pour 1 donc il ne peut pas y avoir de doublon