### PR TITLE
TK-581 : ignorer les vérifications de Quantité si la quantité parente est nulle

### DIFF
--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheMultiProdDerive.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheMultiProdDerive.java
@@ -927,13 +927,12 @@ public class FicheMultiProdDerive extends FicheProdDeriveEdit
 
          // TK-434: Sécuriser la saisie de la quantité utilisée si ce champ est pertinent (visible) c'est-à-dire
          // typeParent est différent de Aucun.
-         // TK-581 : ignorer les vérifications de Quantité si la quantité parente est nulle
-         if (getParentQuantity() != null ) {
-            if (!getTypeParent().equals("Aucun")) {
-
+         // TK-581 : ignorer les vérifications de Quantité si la quantité parente est nulle. Le code s'appuie sur le champ
+         // quantiteMax qui est valorisé avec la quantité présente dans le parent quelque soit son type.
+         // Il est donc null si le parent n'a pas de quantité
+         if (!getTypeParent().equals("Aucun") && getQuantiteMax() != null) {
                // si le champ "quantité" est vide, contrôles liés au paramètre défini dans l'administration (obligatoire ou non)
                if (transfoQuantiteBoxDerive.getValue() == null){
-
                   if (isQuantiteObligatoire){
                      // Si la quantité est obligatoire, on fait défiler vers le champ de quantité dérivée pour attirer l'attention de l'utilisateur.
                      Clients.scrollIntoView(transfoQuantiteBoxDerive);
@@ -951,7 +950,6 @@ public class FicheMultiProdDerive extends FicheProdDeriveEdit
                   }
                }
             }
-         }
 
          ///////// code ci-dessous surprenant car il ne semble rien faire
          // si le dérivé est issu d'un parent connu

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheMultiProdDerive.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheMultiProdDerive.java
@@ -925,23 +925,29 @@ public class FicheMultiProdDerive extends FicheProdDeriveEdit
             throw new WrongValueException(typesBoxDerive, Labels.getLabel("ficheProdDerive.error.type"));
          }
 
-         
          // TK-434: Sécuriser la saisie de la quantité utilisée si ce champ est pertinent (visible) c'est-à-dire
-         // typeParent est différent de Aucun
-         if (!getTypeParent().equals("Aucun")) {
-            // si le champ "quantité" est vide, contrôles liés au paramètre défini dans l'administration (obligatoire ou non)
-            if (transfoQuantiteBoxDerive.getValue() == null){
-               // et la plateforme est configurée pour avoir la saisie de quantité utilisée obligatoire, on bloque l'ajout
-               if (isQuantiteObligatoire){
-                  Clients.scrollIntoView(transfoQuantiteBoxDerive);
-                  // afficher un message d'erreur à côté du champ "quantité utilisée obligatoire"
-                  throw new WrongValueException(transfoQuantiteBoxDerive, Labels.getLabel("ficheMultiProdDerive.validation.quantite"));
-               } else{
-                  // si la valeur du paramètre "quantité utilisée obligatoire" est false,  afficher une fenêtre d'avertissement
-                  boolean userAnswer = MessagesUtils.openQuestionModal(Labels.getLabel("general.warning"),
-                                                                       Labels.getLabel("ficheProdDerive.warning.quantite"));
-                  if (!userAnswer) {
-                     return;
+         // typeParent est différent de Aucun.
+         // TK-581 : ignorer les vérifications de Quantité si la quantité parente est nulle
+         if (getParentQuantity() != null ) {
+            if (!getTypeParent().equals("Aucun")) {
+
+               // si le champ "quantité" est vide, contrôles liés au paramètre défini dans l'administration (obligatoire ou non)
+               if (transfoQuantiteBoxDerive.getValue() == null){
+
+                  if (isQuantiteObligatoire){
+                     // Si la quantité est obligatoire, on fait défiler vers le champ de quantité dérivée pour attirer l'attention de l'utilisateur.
+                     Clients.scrollIntoView(transfoQuantiteBoxDerive);
+                     // Afficher un message d'erreur à côté du champ "quantité utilisée obligatoire"
+                     throw new WrongValueException(transfoQuantiteBoxDerive, Labels.getLabel("ficheMultiProdDerive.validation.quantite"));
+                  //  Si la valeur du paramètre "quantité utilisée obligatoire" est false:
+                  } else{
+                   // Affiche un modal demandant à l'utilisateur s'il souhaite continuer malgré les avertissements sur la quantité
+                     boolean userAnswer = MessagesUtils.openQuestionModal(Labels.getLabel("general.warning"),
+                        Labels.getLabel("ficheProdDerive.warning.quantite"));
+                     // Si l'utilisateur choisit de ne pas continuer (réponse négative), on sort de la méthode ici
+                     if (!userAnswer) {
+                        return;
+                     }
                   }
                }
             }

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheMultiProdDerive.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheMultiProdDerive.java
@@ -931,25 +931,25 @@ public class FicheMultiProdDerive extends FicheProdDeriveEdit
          // quantiteMax qui est valorisé avec la quantité présente dans le parent quelque soit son type.
          // Il est donc null si le parent n'a pas de quantité
          if (!getTypeParent().equals("Aucun") && getQuantiteMax() != null) {
-               // si le champ "quantité" est vide, contrôles liés au paramètre défini dans l'administration (obligatoire ou non)
-               if (transfoQuantiteBoxDerive.getValue() == null){
-                  if (isQuantiteObligatoire){
-                     // Si la quantité est obligatoire, on fait défiler vers le champ de quantité dérivée pour attirer l'attention de l'utilisateur.
-                     Clients.scrollIntoView(transfoQuantiteBoxDerive);
-                     // Afficher un message d'erreur à côté du champ "quantité utilisée obligatoire"
-                     throw new WrongValueException(transfoQuantiteBoxDerive, Labels.getLabel("ficheMultiProdDerive.validation.quantite"));
-                  //  Si la valeur du paramètre "quantité utilisée obligatoire" est false:
-                  } else{
-                   // Affiche un modal demandant à l'utilisateur s'il souhaite continuer malgré les avertissements sur la quantité
-                     boolean userAnswer = MessagesUtils.openQuestionModal(Labels.getLabel("general.warning"),
-                        Labels.getLabel("ficheProdDerive.warning.quantite"));
-                     // Si l'utilisateur choisit de ne pas continuer (réponse négative), on sort de la méthode ici
-                     if (!userAnswer) {
-                        return;
-                     }
+            // si le champ "quantité" est vide, contrôles liés au paramètre défini dans l'administration (obligatoire ou non)
+            if (transfoQuantiteBoxDerive.getValue() == null){
+               if (isQuantiteObligatoire){
+                  // Si la quantité est obligatoire, on fait défiler vers le champ de quantité dérivée pour attirer l'attention de l'utilisateur.
+                  Clients.scrollIntoView(transfoQuantiteBoxDerive);
+                  // Afficher un message d'erreur à côté du champ "quantité utilisée obligatoire"
+                  throw new WrongValueException(transfoQuantiteBoxDerive, Labels.getLabel("ficheMultiProdDerive.validation.quantite"));
+               //  Si la valeur du paramètre "quantité utilisée obligatoire" est false:
+               } else{
+                // Affiche un modal demandant à l'utilisateur s'il souhaite continuer malgré les avertissements sur la quantité
+                  boolean userAnswer = MessagesUtils.openQuestionModal(Labels.getLabel("general.warning"),
+                     Labels.getLabel("ficheProdDerive.warning.quantite"));
+                  // Si l'utilisateur choisit de ne pas continuer (réponse négative), on sort de la méthode ici
+                  if (!userAnswer) {
+                     return;
                   }
                }
             }
+         }
 
          ///////// code ci-dessous surprenant car il ne semble rien faire
          // si le dérivé est issu d'un parent connu

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheProdDeriveEdit.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheProdDeriveEdit.java
@@ -2610,27 +2610,5 @@ public class FicheProdDeriveEdit extends AbstractFicheEditController
       return ObjectTypesFormatters.ILNObjectStatut(getObject().getObjetStatut());
    }
 
-   /**
-    * Récupère la quantité de l'objet parent, qui peut être un Prelevement, un Echantillon ou un ProdDerive.
-    *
-    * @return la quantité de l'objet parent si celui-ci n'est pas null et correspond à l'un des types connus ;
-    *         sinon, retourne null.
-    */
-   public Float getParentQuantity() {
-      if (parentObj != null) {
-         if (typeParent.equals(Prelevement.class.getSimpleName())) {
-            Prelevement prelevement = (Prelevement) parentObj;
-            return prelevement.getQuantite();
-         } else if (typeParent.equals(Echantillon.class.getSimpleName())) {
-            Echantillon echantillon = (Echantillon) parentObj;
-            return echantillon.getQuantite();
-         } else if (typeParent.equals(ProdDerive.class.getSimpleName())) {
-            ProdDerive parentDerive = (ProdDerive) parentObj;
-            return parentDerive.getQuantite();
-         }
-      }
-      return null;
-   }
-
 
 }

--- a/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheProdDeriveEdit.java
+++ b/tumorotek-webapp/src/main/java/fr/aphp/tumorotek/action/prodderive/FicheProdDeriveEdit.java
@@ -2610,5 +2610,27 @@ public class FicheProdDeriveEdit extends AbstractFicheEditController
       return ObjectTypesFormatters.ILNObjectStatut(getObject().getObjetStatut());
    }
 
+   /**
+    * Récupère la quantité de l'objet parent, qui peut être un Prelevement, un Echantillon ou un ProdDerive.
+    *
+    * @return la quantité de l'objet parent si celui-ci n'est pas null et correspond à l'un des types connus ;
+    *         sinon, retourne null.
+    */
+   public Float getParentQuantity() {
+      if (parentObj != null) {
+         if (typeParent.equals(Prelevement.class.getSimpleName())) {
+            Prelevement prelevement = (Prelevement) parentObj;
+            return prelevement.getQuantite();
+         } else if (typeParent.equals(Echantillon.class.getSimpleName())) {
+            Echantillon echantillon = (Echantillon) parentObj;
+            return echantillon.getQuantite();
+         } else if (typeParent.equals(ProdDerive.class.getSimpleName())) {
+            ProdDerive parentDerive = (ProdDerive) parentObj;
+            return parentDerive.getQuantite();
+         }
+      }
+      return null;
+   }
+
 
 }


### PR DESCRIPTION
Le code contient 4 blocs `if` imbriqués. Je me demande s'il peut être amélioré et si le nombre de `if` peut être réduit sans impacter la lisibilité ou la maintenabilité. Est-ce que tu garderais cette structure telle quelle ou est-ce que tu regrouperais deux ou plusieurs `if` ensemble ?